### PR TITLE
Fix links in developer handbook

### DIFF
--- a/engineering/handbook/README.md
+++ b/engineering/handbook/README.md
@@ -19,9 +19,9 @@ We use Slack for direct communication and especially [#dev channel](https://scau
 
 ### Important topics
 
-* [Idea -> Production](/handbook/idea-to-production.md)
-* [Github workflow](/handbook/gitflow.md)
+* [Idea -> Production](/engineering/handbook/idea-to-production.md)
+* [Github workflow](/engineering/handbook/gitflow.md)
 * Sprint process
-* [Development environment](/handbook/development.md)
+* [Development environment](/engineering/handbook/development.md)
 * Staging environment
 * Production environment


### PR DESCRIPTION
Some of the links stopped working when the handbook was moved into `/engineering`.