### PR TITLE
Update git process

### DIFF
--- a/engineering/handbook/gitflow.md
+++ b/engineering/handbook/gitflow.md
@@ -10,34 +10,25 @@ Each software repository should have the following branches:
 
 ### Overview
 
-tl; dr -> we use the [git flow](https://nvie.com/posts/a-successful-git-branching-model/) approach to branching, with peer-review on
-all PRs. Once reviewing begins, we _merge_ the parent branch into the PR until review(s) are done, so as not to destroy comment
-history. Once reviewing is done, we rebase & squash to a single / as few reasonable commit(s) as possible, so merges into the parent
-branch are always fast-forward.
+We work using feature branches that get applied straight to `master` (or `develop` in the case of the mobile app), with 
+peer-review on all PRs. Once reviewing begins, we _merge_ the parent branch into the PR until review(s) are done, so as 
+not to destroy comment history. Once reviewing is done, we rebase & squash to a single / as few reasonable commit(s) as
+possible, so merges into the parent branch are always fast-forward.
 
-All work except incredibly time-critical hotfixes is done via Pull Requests. This means that working on an issue begins by checking out
-a branch from its parent (e.g., `develop`), working on it a bunch and then opening a pull request when you are ready for the code to
-be reviewed.
+All work except incredibly time-critical hotfixes is done via Pull Requests. This means that working on an issue begins by
+checking out a branch from its parent (e.g., `master`), working on it a bunch and then opening a pull request when you are
+ready for the code to be reviewed.
 
-Once the pull request is accepted, you should clean it up according to our rules about the format of git commits (see below). It can
-then be merged into its parent branch. Below are some requirements on the structure and format of commits that get merged into
-`master`/`develop`, that you should check if your squashed PR adheres to.
+Once the pull request is accepted, you should clean it up according to our rules about the format of git commits (see 
+below). It can then be merged into its parent branch. Below are some requirements on the structure and format of commits
+that get merged into `master`/`develop`, that you should check if your squashed PR adheres to.
 
 ### Git commit rules
 
-A git commit must make sense on its own, as a stand-alone unit of change. Additionally, there are some restrictions on how to write commits to ensure a consistent style and form:
-
-* Commit text and messages are written in the current tense, e.g., "Remove logout button from application", not "Removed logout button"
-* Commit titles must refer to the issue they relate to by prefixing the issue id e.g., `SCAUT-123 Remove logout button`
-* Commit bodies must generally include a list of dash-prefixed items that briefly and specifically ensure you understand exactly what has changed. For example:
-    * Bad commit body line: "Deprecate unneeded API route" (no dash, and too vague)
-    * Good commit body line: "- Remove /api/v2/patient/foo"
-    * Bad commit body line: "- Refactored patient search" (past tense, too vague)
-    * Good commit body line: "- Modify searchPatients to always filter based on current users Clinic access"
-    * Bad commit body line: "- Add getPatientProfilesInBulk because it is useful for the web API to be able to fetch them like this" (unnecessarily verbose; no need to specify **why**)
-    * Good commit body line: "- Add getPatientProfilesInBulk to fetch multiple profiles at once"
-* Commits can be used to execute commands in YouTrack, such as altering the state of the issue. You should use this
-to your advantage: You can move an issue to `Done` state automatically, f.ex. See [VCS actions](https://www.jetbrains.com/help/youtrack/standalone/Apply-Commands-in-VCS-Commits.html) for more information on this.
+You can learn a lot by just looking at our existing commits, and observing the general format and approach taken. Beyond
+that, please read [RomuloOliveira's commit guide](https://github.com/RomuloOliveira/commit-messages-guide), which nicely
+sums up a lot of our opinions on the subject as well. Finally, commits should refer explicitly to the issue ID to which they
+are related, preferably as a prefix in the title, or in the commit body if it touches on multiple issues.
 
 **Suggestions for working with git and the git history**
 


### PR DESCRIPTION
This commit updates the git process to more accurately reflect our actual process, and link to relevant material. It also removes the
references to YouTrack. We've discussed moving towards a model where we drop `develop` when we can, to iterate onto production quicker. 

- Link to RomuloOliviera's commit guide
- Remove section on YouTrack
- Rephrase to clarify moving away from git flow and towards a simpler, feature-branch-centric model where we generally merge straight into `master` if we can.